### PR TITLE
added "practice" batch used in RFB annenv

### DIFF
--- a/batches/aapb-annenv-role-filler-binder-11.txt
+++ b/batches/aapb-annenv-role-filler-binder-11.txt
@@ -1,4 +1,4 @@
-# from https://github.com/clamsproject/aapb-annenv-creditparsing/issues/11
+# for more details, see https://github.com/clamsproject/aapb-annenv-role-filler-binder/issues/11 
 cpb-aacip-259-nv998n13
 cpb-aacip-507-930ns0mg7g
 cpb-aacip-512-cj87h1fh8t


### PR DESCRIPTION
documenting batch compiled in https://github.com/clamsproject/aapb-annenv-role-filler-binder/issues/11 and used in the first "practice" round of RFB annotation work.